### PR TITLE
SDMコンテンツの表示

### DIFF
--- a/content/contents/contents.yml
+++ b/content/contents/contents.yml
@@ -1,0 +1,17 @@
+- name:
+    ja: Web360square
+    en: Web360square
+  image: https://user-images.githubusercontent.com/38515249/94395386-8a312500-019a-11eb-98c2-fe004968b4c4.png
+  summary:
+    ja: テストテストテストテスト
+    en: TestTestTestTest
+  home: https://sdm-wg.github.io/web360square-vue/
+
+- name:
+    ja: SDM Ontology
+    en: SDM Ontology
+  image: https://tlab.hongo.wide.ad.jp/wp-content/uploads/2020/09/Figure_SDMO-1.png
+  summary:
+    ja: テストテストテストテスト
+    en: TestTestTestTest
+  home: https://tlab.hongo.wide.ad.jp/sdmo/

--- a/content/contents/contents.yml
+++ b/content/contents/contents.yml
@@ -3,7 +3,7 @@
     en: Web360square
   image: https://user-images.githubusercontent.com/38515249/94395386-8a312500-019a-11eb-98c2-fe004968b4c4.png
   summary:
-    ja: Web360square は，360 度動画とオブジェクトベース立体音響をインタラクティブに再生可能な Web アプリケーションです．
+    ja: 360 度動画とオブジェクトベース立体音響をインタラクティブに再生可能な Web アプリケーションです．
     en: Web360square is an application that plays 360-degree video and object-based 3D sounds interactively on the Web.
   home: https://sdm-wg.github.io/web360square-vue/
 
@@ -12,6 +12,6 @@
     en: SDM Ontology
   image: https://tlab.hongo.wide.ad.jp/wp-content/uploads/2020/09/Figure_SDMO-1.png
   summary:
-    ja: SDM Ontology は，3次元映像・音声メディアやセンサによるデータメディアなどの収録を対象とし，収録環境から編集系，再生系まで，詳細なメタデータを階層構造に整理して記述するためのオントロジーです．
-    en: SDMO is an ontology to organize and describe detailed metadata in a hierarchical structure for 3D video/audio media and sensor-based data media.
+    ja: 3次元映像・音声メディアやセンサによるデータなどの収録を対象とし，詳細なメタデータを階層構造に整理して記述するためのオントロジーです．
+    en: SDMO is an ontology to describe metadata in a hierarchical structure for 3D video/audio media and sensor-based data.
   home: https://tlab.hongo.wide.ad.jp/sdmo/

--- a/content/contents/contents.yml
+++ b/content/contents/contents.yml
@@ -3,8 +3,8 @@
     en: Web360square
   image: https://user-images.githubusercontent.com/38515249/94395386-8a312500-019a-11eb-98c2-fe004968b4c4.png
   summary:
-    ja: テストテストテストテスト
-    en: TestTestTestTest
+    ja: Web360square は，360 度動画とオブジェクトベース立体音響をインタラクティブに再生可能な Web アプリケーションです．
+    en: Web360square is an application that plays 360-degree video and object-based 3D sounds interactively on the Web.
   home: https://sdm-wg.github.io/web360square-vue/
 
 - name:
@@ -12,6 +12,6 @@
     en: SDM Ontology
   image: https://tlab.hongo.wide.ad.jp/wp-content/uploads/2020/09/Figure_SDMO-1.png
   summary:
-    ja: テストテストテストテスト
-    en: TestTestTestTest
+    ja: SDM Ontology は，3次元映像・音声メディアやセンサによるデータメディアなどの収録を対象とし，収録環境から編集系，再生系まで，詳細なメタデータを階層構造に整理して記述するためのオントロジーです．
+    en: SDMO is an ontology to organize and describe detailed metadata in a hierarchical structure for 3D video/audio media and sensor-based data media.
   home: https://tlab.hongo.wide.ad.jp/sdmo/

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -78,4 +78,19 @@ module.exports = function (api) {
       });
     }
   });
+
+  // Collect contents
+  api.loadSource(({ addCollection }) => {
+    const contentCollection = addCollection({
+      typeName: "Content",
+    });
+
+    const basePath = "./content/contents";
+    const contents = fetchYaml(basePath);
+    for (const item of contents) {
+      contentCollection.addNode({
+        ...item,
+      });
+    }
+  });
 };

--- a/src/components/helpers/ContentCard.vue
+++ b/src/components/helpers/ContentCard.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="w-full md:w-1/2 lg:w-1/3 xl:w-1/4 p-4">
+    <div
+      class="rounded overflow-hidden shadow-lg transition-set"
+      :class="{
+        'bg-gray-900': isDark,
+        'bg-white': !isDark,
+      }"
+    >
+      <div class="relative w-full pb-full">
+        <g-image
+          v-if="content.node.image"
+          class="absolute w-full h-full object-cover"
+          :src="content.node.image"
+          :alt="content.node.name[language]"
+        />
+        <g-image
+          v-else
+          class="absolute w-full h-full object-cover bg-white"
+          src="~/assets/images/sdm-logo-square.png"
+          :alt="content.node.name[language]"
+        />
+      </div>
+      <div
+        class="pt-4 font-bold text-xl text-center transition-set"
+        :class="{
+          'text-gray-100': isDark,
+          'text-gray-900': !isDark,
+        }"
+      >
+        {{ content.node.name[language] }}
+      </div>
+      <div
+        class="text-lg text-center transition-set"
+        :class="{
+          'text-gray-300': isDark,
+          'text-gray-700': !isDark,
+        }"
+      >
+        {{ content.node.summary[language] }}
+      </div>
+      <div
+        class="py-4 text-base text-center transition-set"
+        :class="{
+          'text-gray-300': isDark,
+          'text-gray-700': !isDark,
+        }"
+      >
+        <flex-link
+          v-if="content.node.home"
+          class="mx-1"
+          :class="{
+            'hover:text-blue-500': isDark,
+            'hover:text-orange-500': !isDark,
+          }"
+          :to="content.node.home"
+        >
+          <font-awesome :icon="['fas', 'home']" size="lg" fixed-width />
+        </flex-link>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import localeMixin from "~/mixins/locale.js";
+
+export default {
+  name: "ContentCard",
+  mixins: [localeMixin],
+  props: {
+    isDark: {
+      type: Boolean,
+      required: true,
+    },
+    content: {
+      type: Object,
+      required: true,
+    },
+  },
+};
+</script>

--- a/src/components/standalone/ContentSection.vue
+++ b/src/components/standalone/ContentSection.vue
@@ -1,0 +1,61 @@
+<template>
+  <SectionWrapper :isDark="isDark" :isEven="isEven" :sectionId="sectionId">
+    <template v-slot:heading>{{ $t("content.heading") }}</template>
+    <ContentCard
+      v-for="content in $static.contents.edges"
+      :key="content.node.id"
+      :isDark="isDark"
+      :content="content"
+    />
+  </SectionWrapper>
+</template>
+
+<static-query>
+query {
+  contents: allContent(sortBy: "id", order: ASC) {
+    edges {
+      node {
+        id
+        name {
+          ja
+          en
+        }
+        image
+        summary {
+          ja
+          en
+        }
+        home
+      }
+    }
+  }
+}
+</static-query>
+
+<script>
+import SectionWrapper from "~/components/helpers/SectionWrapper.vue";
+import ContentCard from "~/components/helpers/ContentCard.vue";
+
+export default {
+  name: "ContentSection",
+  props: {
+    isDark: {
+      type: Boolean,
+      required: true,
+    },
+    isEven: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    sectionId: {
+      type: String,
+      required: true,
+    },
+  },
+  components: {
+    SectionWrapper,
+    ContentCard,
+  },
+};
+</script>

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -47,7 +47,7 @@
     }
   },
   "content": {
-    "heading": "Contents"
+    "heading": "Open Sources / Open Data"
   },
   "contact": {
     "heading": "Contact",

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -46,6 +46,9 @@
       "heading": "Japanese Publications"
     }
   },
+  "content": {
+    "heading": "Contents"
+  },
   "contact": {
     "heading": "Contact",
     "address": {
@@ -57,15 +60,12 @@
       "content": "Email:"
     }
   },
-
   "post": {
     "heading": "Posts"
   },
-
   "tag": {
     "heading": "Tags"
   },
-
   "archive": {
     "heading": "Archives"
   }

--- a/src/locales/ja-jp.json
+++ b/src/locales/ja-jp.json
@@ -46,6 +46,9 @@
       "heading": "Japanese Publications"
     }
   },
+  "content": {
+    "heading": "SDM 試作システム"
+  },
   "contact": {
     "heading": "Contact",
     "address": {
@@ -57,15 +60,12 @@
       "content": "Email:"
     }
   },
-
   "post": {
     "heading": "Posts"
   },
-
   "tag": {
     "heading": "Tags"
   },
-
   "archive": {
     "heading": "Archives"
   }

--- a/src/locales/ja-jp.json
+++ b/src/locales/ja-jp.json
@@ -47,7 +47,7 @@
     }
   },
   "content": {
-    "heading": "SDM 試作システム"
+    "heading": "オープンソース / オープンデータ"
   },
   "contact": {
     "heading": "Contact",

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -11,7 +11,8 @@
       :isEven="true"
       sectionId="publications"
     />
-    <ContactSection :isDark="isDark" :isEven="false" sectionId="contact" />
+    <ContentSection :isDark="isDark" :isEven="false" sectionId="content" />
+    <ContactSection :isDark="isDark" :isEven="true" sectionId="contact" />
   </Layout>
 </template>
 
@@ -22,6 +23,7 @@ import EventSection from "~/components/standalone/EventSection.vue";
 import NewsSection from "~/components/standalone/NewsSection.vue";
 import MemberSection from "~/components/standalone/MemberSection.vue";
 import PublicationSection from "~/components/standalone/PublicationSection.vue";
+import ContentSection from "~/components/standalone/ContentSection.vue";
 import ContactSection from "~/components/standalone/ContactSection.vue";
 
 import colorSchemeMixin from "~/mixins/colorScheme.js";
@@ -39,6 +41,7 @@ export default {
     NewsSection,
     MemberSection,
     PublicationSection,
+    ContentSection,
     ContactSection,
   },
 };


### PR DESCRIPTION
## Issue

Closes: #6 

## 要旨

- Contents セクションを追加
- `content/contents/contents.yml` に追加することでカードを追加できる

## ToDo

- [x] `contents` という用語の検討 (∵予約語と衝突しそう)
- [x] 何を載せるか相談
- [x] 説明文・画像の選定
